### PR TITLE
Update OGP image and event details.

### DIFF
--- a/src/components/layouts/base.tsx
+++ b/src/components/layouts/base.tsx
@@ -9,8 +9,8 @@ import type { FC } from "react";
 
 export const metadata = {
   title: {
-    template: "%s | ETHTokyo'24",
-    default: "ETHTokyo'24",
+    template: "%s | ETHTokyo'25",
+    default: "ETHTokyo'25",
   },
   description: "The Japanese Ethereum Community Hackathon & Conference",
   keywords: ["Ethereum", "Japan", "Tokyo", "Blockchain", "Hackathon"],
@@ -22,13 +22,13 @@ export const metadata = {
     telephone: false,
   },
   openGraph: {
-    title: "ETHTokyo 2024",
+    title: "ETHTokyo 2025",
     description: "The Japanese Ethereum Community Hackathon & Conference",
-    url: "https://www.ethtokyo.com",
-    siteName: "www.ethtokyo.com",
+    url: "https://ethtokyo.org/",
+    siteName: "ethtokyo.org",
     images: [
       {
-        url: "https://www.ethtokyo.com/logo/ETHTokyoLogo.png",
+        url: "https://ethtokyo.org/logo/ETHTokyoLogo.png",
         width: 800,
         height: 600,
       },
@@ -38,12 +38,12 @@ export const metadata = {
   },
   twitter: {
     card: "summary_large_image",
-    title: "ETHTokyo 2024",
+    title: "ETHTokyo 2025",
     description: "The Japanese Ethereum Community Hackathon & Conference",
     siteId: "1511737631948034048",
     creator: "@Ethereum_JP",
     creatorId: "1511737631948034048",
-    images: ["https://www.ethtokyo.com/logo/ETHTokyoLogo.png"],
+    images: ["https://ethtokyo.org/logo/ETHTokyoLogo.png"],
   },
   themeColor: [
     { media: "(prefers-color-scheme: light)", color: "#B8FAF6" },
@@ -75,7 +75,7 @@ const fontInter = Inter({
 // const styleCache = createCache({ key: 'next' });
 
 const Layout: FC<PageProps> = ({ pageTitle, children }) => {
-  const siteTitle = "ETHTokyo'24";
+  const siteTitle = "ETHTokyo'25";
   const baseLayoutStyle = css``;
   const mainLayoutStyle = css``;
 

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,20 +15,20 @@ const CustomDocument = (props: NoncedDocument) => {
     <Html prefix="og: https://ogp.me/ns#" lang="en" nonce={props.nonce}>
       <Head nonce={props.nonce}>
         <link rel="icon" href="/favicon.ico" />
-        <meta property="og:url" content="www.ethtokyo.com" />
+        <meta property="og:url" content="ethtokyo.org" />
         <meta property="og:type" content="website" />
-        <meta property="og:title" content="ETHTokyo 2024" />
+        <meta property="og:title" content="ETHTokyo 2025" />
         <meta
           property="og:image"
-          content="https://www.ethtokyo.com/images/thumbnail.jpg"
+          content="https://ethtokyo.org/images/thumbnail.jpg"
         />
         <meta
           property="og:description"
-          content="ETHTokyo 2024 is a Ethereum hackathon & conference organized by Japanese Ethereum enthusiasts."
+          content="ETHTokyo 2025 is a Ethereum hackathon & conference organized by Japanese Ethereum enthusiasts."
         />
         <meta
           name="description"
-          content="ETHTokyo 2024 is a Ethereum hackathon & conference organized by Japanese Ethereum enthusiasts."
+          content="ETHTokyo 2025 is a Ethereum hackathon & conference organized by Japanese Ethereum enthusiasts."
         />
         <meta name="twitter:card" content="summary" />
         <meta name="twitter:card" content="summary_large_image" />


### PR DESCRIPTION
I thought it would be better to have an OGP image, so I modified it! I have also corrected the 2024 to 2025 and the domain.

- Updated metadata and title references from ETHTokyo 2024 to ETHTokyo 2025.
- Changed website URLs from www.ethtokyo.com to ethtokyo.org.
- Updated paths for images and assets to align with the new domain.

Please check, if you like.