### PR TITLE
スポンサー申込みの導線をEnterprise SponsorとCommunity Sponsorで分けます

### DIFF
--- a/src/components/organisms/AboutSection.tsx
+++ b/src/components/organisms/AboutSection.tsx
@@ -304,15 +304,26 @@ export const Temp_formSection = () => {
           ETHTokyo'25 is currently accepting sponsors. Please contact us if you
           are interested in sponsoring the event.
         </p>
-        <Button
-          href="https://ethtokyo.deform.cc/25-sponsor-application"
-          external
-          size="medium"
-          variant="primary"
-          icon={<BiMoney />}
-        >
-          <span css={css`color: ${neutral.White};`}>Sponsor event</span>
-        </Button>
+        <div css={css`display: flex; gap: 1rem; flex-wrap: wrap;`}>
+          <Button
+            href="https://ethtokyo.deform.cc/25-sponsor-application"
+            external
+            size="medium"
+            variant="primary"
+            icon={<BiMoney />}
+          >
+            <span css={css`color: ${neutral.White};`}>Enterprise Sponsor</span>
+          </Button>
+          <Button
+            href="https://app.moongate.id/e/ethtokyo2025"
+            external
+            size="medium"
+            variant="primary"
+            icon={<BiMoney />}
+          >
+            <span css={css`color: ${neutral.White};`}>Community Sponsor</span>
+          </Button>
+        </div>
       </div>
     </div>
   );

--- a/src/components/organisms/Footer/index.tsx
+++ b/src/components/organisms/Footer/index.tsx
@@ -163,7 +163,14 @@ const Footer: FC<ComponentProps> = ({ children }) => {
               target="_blank"
               rel="noreferrer"
             >
-              Event sponsorship
+              Enterprise Sponsorship
+            </a>
+            <a
+              href="https://app.moongate.id/e/ethtokyo2025"
+              target="_blank"
+              rel="noreferrer"
+            >
+              Community Sponsorship
             </a>
           </div>
         </div>


### PR DESCRIPTION
8/20 のSponsor MTGでCommunity Sponsor申込みへの導線を改善したいという話が出まして、
以下のように導線を修正します。Community Sponsor 申込みに関してはDeForm経由ではなく、直接Moongateから申し込みを行ってもらうように修正しました。

### 変更箇所1
<img width="1417" height="775" alt="CleanShot 2025-08-21 at 02 27 22" src="https://github.com/user-attachments/assets/37532bc9-05c3-44d3-bc60-a14af765476b" />

### 変更箇所2
<img width="620" height="221" alt="CleanShot 2025-08-21 at 02 28 52" src="https://github.com/user-attachments/assets/88b14f88-baa8-49d1-ab48-83e78a53b442" />
